### PR TITLE
Update Emerge tools integration to use latest best practices and add snapshot testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
-      - name: Generate Android release bundle
-        run: ./gradlew :paymentsheet-example:bundleRelease
-      - name: Upload artifact to Emerge
-        uses: EmergeTools/emerge-upload-action@3477b597fc62054136eb6f499e0ba78144f8a999
-        with:
-          artifact_path: paymentsheet-example/build/outputs/bundle/release/paymentsheet-example-release.aab
-          emerge_api_key: ${{ secrets.EMERGE_API_KEY }}
-          build_type: pull_request
+      - name: Upload release bundle to Emerge
+        run: ./gradlew :paymentsheet-example:emergeUploadReleaseAab
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+
+  # Use emerge tools to run snapshot tests
+  payment-sheet-snapshot-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/stripe_setup
+      - name: Upload snapshots bundle to Emerge
+        run: ./gradlew :paymentsheet-example:emergeUploadSnapshotBundleDebug
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
 
   check-for-untranslated-strings:
     name: Check for untranslated strings

--- a/.github/workflows/financialconnections_pull_request.yml
+++ b/.github/workflows/financialconnections_pull_request.yml
@@ -8,11 +8,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
-      - name: Generate Android release bundle
-        run: ./gradlew :financial-connections-example:bundleRelease
-      - name: Upload artifact to Emerge
-        uses: EmergeTools/emerge-upload-action@3477b597fc62054136eb6f499e0ba78144f8a999
-        with:
-          artifact_path: financial-connections-example/build/outputs/bundle/release/financial-connections-example-release.aab
-          emerge_api_key: ${{ secrets.EMERGE_API_KEY }}
-          build_type: release
+      - name: Upload release bundle to Emerge
+        run: ./gradlew :financial-connections-example:emergeUploadReleaseAab
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+
+  # Use emerge tools to run snapshot tests
+  snapshot-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/stripe_setup
+      - name: Upload snapshots bundle to Emerge
+        run: ./gradlew :financial-connections-example:emergeUploadSnapshotBundleDebug
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}

--- a/.github/workflows/identity_pull_request.yml
+++ b/.github/workflows/identity_pull_request.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
       - name: Upload release bundle to Emerge
-        run: ./gradlew :identity-example:emergeUploadReleaseAab
+        run: ./gradlew :identity-example:emergeUploadTheme1ReleaseAab
         env:
           EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
 
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
       - name: Upload snapshots bundle to Emerge
-        run: ./gradlew :identity-example:emergeUploadSnapshotBundleDebug
+        run: ./gradlew :identity-example:emergeUploadSnapshotBundleTheme1Debug
         env:
           EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
 

--- a/.github/workflows/identity_pull_request.yml
+++ b/.github/workflows/identity_pull_request.yml
@@ -86,11 +86,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
-      - name: Generate Android release bundle
-        run: ./gradlew :identity-example:bundleRelease
-      - name: Upload artifact to Emerge
-        uses: EmergeTools/emerge-upload-action@3477b597fc62054136eb6f499e0ba78144f8a999
-        with:
-          artifact_path: identity-example/build/outputs/bundle/theme1Release/identity-example-theme1-release.aab
-          emerge_api_key: ${{ secrets.EMERGE_API_KEY }}
-          build_type: pull_request
+      - name: Upload release bundle to Emerge
+        run: ./gradlew :identity-example:emergeUploadReleaseAab
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+
+  # Use emerge tools to run snapshot tests
+  snapshot-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/stripe_setup
+      - name: Upload snapshots bundle to Emerge
+        run: ./gradlew :identity-example:emergeUploadSnapshotBundleDebug
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,37 +13,52 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
-      - name: Generate Android release bundle for Identity example app
-        run: ./gradlew :identity-example:bundleRelease
-      - name: Upload artifact to Emerge
-        uses: EmergeTools/emerge-upload-action@3477b597fc62054136eb6f499e0ba78144f8a999
-        with:
-          artifact_path: identity-example/build/outputs/bundle/theme1Release/identity-example-theme1-release.aab
-          emerge_api_key: ${{ secrets.EMERGE_API_KEY }}
-          build_type: push
+      - name: Upload Identity example release bundle to Emerge
+        run: ./gradlew :identity-example:emergeUploadReleaseAab
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+  snapshot-identity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/stripe_setup
+      - name: Upload Identity example snapshots bundle to Emerge
+        run: ./gradlew :identity-example:emergeUploadSnapshotBundleTheme1Debug
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
   upload-financial-connections:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
-      - name: Generate Android release bundle for Financial Connections example app
-        run: ./gradlew :financial-connections-example:bundleRelease
-      - name: Upload artifact to Emerge
-        uses: EmergeTools/emerge-upload-action@3477b597fc62054136eb6f499e0ba78144f8a999
-        with:
-          artifact_path: financial-connections-example/build/outputs/bundle/release/financial-connections-example-release.aab
-          emerge_api_key: ${{ secrets.EMERGE_API_KEY }}
-          build_type: push
+      - name: Upload Financial Connections example release bundle to Emerge
+        run: ./gradlew :financial-connections-example:emergeUploadReleaseAab
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+  snapshot-financial-connections:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/stripe_setup
+      - name: Upload Financial Connections example snapshots bundle to Emerge
+        run: ./gradlew :financial-connections-example:emergeUploadSnapshotBundleDebug
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
   upload-payment-sheet:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
-      - name: Generate Android release bundle for Payment Sheet example app
-        run: ./gradlew :paymentsheet-example:bundleRelease
-      - name: Upload artifact to Emerge
-        uses: EmergeTools/emerge-upload-action@3477b597fc62054136eb6f499e0ba78144f8a999
-        with:
-          artifact_path: paymentsheet-example/build/outputs/bundle/release/paymentsheet-example-release.aab
-          emerge_api_key: ${{ secrets.EMERGE_API_KEY }}
-          build_type: push
+      - name: Upload Payment sheet example release bundle to Emerge
+        run: ./gradlew :paymentsheet-example:emergeUploadReleaseAab
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}
+  snapshot-payment-sheet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/stripe_setup
+      - name: Upload Payment sheet example snapshots bundle to Emerge
+        run: ./gradlew :paymentsheet-example:emergeUploadSnapshotBundleDebug
+        env:
+          EMERGE_API_KEY: ${{ secrets.EMERGE_API_KEY }}

--- a/build-configuration/android-application.gradle
+++ b/build-configuration/android-application.gradle
@@ -18,7 +18,7 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion rootProject.ext.compileSdkVersion
         versionName VERSION_NAME
     }

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ plugins {
     id 'com.google.devtools.ksp' version '1.9.22-1.0.17' apply false
     id 'dev.drewhamilton.poko' version '0.15.2' apply false
     id 'org.jetbrains.kotlin.jvm' version '1.9.22' apply false
+    id 'com.emergetools.android' version '4.0.0-beta02' apply false
 }
 
 apply plugin: "io.gitlab.arturbosch.detekt"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -29,6 +29,7 @@ ext.versions = [
         detekt                      : '1.23.6',
         diskLruCache                : '2.0.2',
         dokka                       : '1.9.10',
+        emergeSnapshots             : '1.1.4',
         espresso                    : '3.5.1',
         firebaseAppDistribution     : '4.0.1',
         fuel                        : '2.3.1',
@@ -201,6 +202,9 @@ ext.testLibs = [
                 truth      : "androidx.test.ext:truth:${versions.androidTest}",
                 uiAutomator: "androidx.test.uiautomator:uiautomator:${versions.uiAutomator}",
                 workManager: "androidx.work:work-testing:${versions.workManager}",
+        ],
+        emerge               : [
+                snapshots     : "com.emergetools.snapshots:snapshots:${versions.emergeSnapshots}",
         ],
         espresso             : [
                 accessibility : "androidx.test.espresso:espresso-accessibility:${versions.espresso}",

--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -1,11 +1,22 @@
 apply from: configs.androidApplication
 
+apply plugin: 'com.emergetools.android'
 apply plugin: 'com.google.firebase.appdistribution'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 
-
 def testEnvironment = System.getenv("test_environment") ?: "production"
+
+emerge {
+    apiToken = System.getenv("EMERGE_API_KEY")
+
+    vcs {
+        gitHub {
+            repoOwner = "EmergeTools"
+            repoName = "stripe-android"
+        }
+    }
+}
 
 android {
     defaultConfig {
@@ -75,6 +86,7 @@ dependencies {
     testImplementation testLibs.androidx.junit
     testImplementation testLibs.junit
 
+    androidTestImplementation testLibs.emerge.snapshots
     androidTestImplementation testLibs.espresso.core
     androidTestImplementation testLibs.androidx.composeUi
 }

--- a/identity-example/build.gradle
+++ b/identity-example/build.gradle
@@ -1,8 +1,20 @@
 apply from: configs.androidApplication
 
+apply plugin: 'com.emergetools.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 
 assemble.dependsOn('lint')
+
+emerge {
+    apiToken = System.getenv("EMERGE_API_KEY")
+
+    vcs {
+        gitHub {
+            repoOwner = "EmergeTools"
+            repoName = "stripe-android"
+        }
+    }
+}
 
 android {
     defaultConfig {
@@ -65,6 +77,8 @@ dependencies {
     implementation libs.material
 
     testImplementation testLibs.junit
+
+    androidTestImplementation testLibs.emerge.snapshots
 
     // TODO(ccen) re-enable and investigate leak in Camera
     // debugImplementation libs.leakCanary

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -1,5 +1,6 @@
 apply from: configs.androidApplication
 
+apply plugin: 'com.emergetools.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'shot'
 
@@ -10,6 +11,17 @@ def getBackendUrl() {
 
 def getGooglePlacesApiKey() {
     return findProperty('STRIPE_PAYMENTSHEET_EXAMPLE_GOOGLE_PLACES_API_KEY') ?: ""
+}
+
+emerge {
+    apiToken = System.getenv("EMERGE_API_KEY")
+
+    vcs {
+        gitHub {
+            repoOwner = "EmergeTools"
+            repoName = "stripe-android"
+        }
+    }
 }
 
 dependencies {
@@ -61,6 +73,7 @@ dependencies {
     androidTestImplementation testLibs.androidx.testRunner
     androidTestImplementation testLibs.androidx.truth
     androidTestImplementation testLibs.androidx.uiAutomator
+    androidTestImplementation testLibs.emerge.snapshots
     androidTestImplementation(testLibs.espresso.accessibility) {
         exclude group: 'org.checkerframework', module: 'checker'
     }


### PR DESCRIPTION
# Summary
Updates Emerge Tools integration to use best practices. Emerge has deprecated the GitHub action for Android in favor of the Gradle plugin. 

While I was at it, I was curious about how many snapshot tests this would generate, since Emerge snapshot testing just requires one `androidTest` dependency and a single gradle task invocation. Looks like with no effort, we get 66 snapshots across `identity`, `financial-connections` and `paymentsheet`!

This did require updating the minSdk of the sample applications to 23, but this should have no effect on the minSdk of the underlying libraries.

# Motivation
We're doing this as Stripe recently reached out about an issue with their existing integration. We noticed a few old practices being used, so we figured we'd help out and update everything to the latest and greatest 😄 .

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshot (test)s
These are public so anyone can view them, by default they'll be behind authentication:
Identity: https://www.emergetools.com/app/example/android/snapshot/examp_rQtB3MhnSdtp
Financial connections: https://www.emergetools.com/app/example/android/snapshot/examp_G3poxi55qvw2
PaymentSheet: https://www.emergetools.com/app/example/android/snapshot/examp_z9sDRsg7WS8w

# Changelog
N/A